### PR TITLE
Move activity to background on create

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -24,6 +24,7 @@ import java.util.*
 class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        moveTaskToBack(true)
 
         when(intent.action) {
             Intent.ACTION_VIEW -> {


### PR DESCRIPTION
To make the activity low priority and not interfere with other apps, move it to the background immediately in onCreate() using moveTaskToBack(true).

This will move the entire task containing this activity to the back of the stack when it is created, so it does not take foreground focus or receive user interaction.