### PR TITLE
fix: correctly convert timezone offset from Java TimeZone.getRawOffset() to arg for golang time.FixedZone

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/TimeZoneModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/TimeZoneModule.kt
@@ -14,7 +14,7 @@ class TimeZoneModule(service: Service) : Module<Unit>(service) {
         while (true) {
             val timeZone = TimeZone.getDefault()
 
-            Clash.notifyTimeZoneChanged(timeZone.id, timeZone.rawOffset)
+            Clash.notifyTimeZoneChanged(timeZone.id, timeZone.rawOffset / 1000)
 
             timeZones.receive()
         }


### PR DESCRIPTION
When overriding timezone for mihomo core, `timeZone.rawOffset` is in milliseconds while `offset` argument for golang `time.FixedZone` is in seconds. But the ratio 1000 is missing in the code.

Seems not affecting anything for now, but may cause problems in the future. The PR fixes this.