### PR TITLE
fix: (native conn.go) `closeMatch` logic should really close all matching conns; closes PacketConn also

### DIFF
--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -14,7 +14,7 @@ func CloseAllConnections() {
 
 func closeMatch(filter func(conn C.Connection) bool) {
 	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
-		if filter(cc) {
+		if filter(c) {
 			_ = c.Close()
 		}
 		return true

--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -14,11 +14,9 @@ func CloseAllConnections() {
 
 func closeMatch(filter func(conn C.Connection) bool) {
 	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
-		if cc, ok := c.(C.Connection); ok {
-			if filter(cc) {
-				_ = c.Close()
-				return true
-			}
+		if filter(cc) {
+			_ = c.Close()
+			return true
 		}
 		return true
 	})

--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -16,7 +16,6 @@ func closeMatch(filter func(conn C.Connection) bool) {
 	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
 		if filter(cc) {
 			_ = c.Close()
-			return true
 		}
 		return true
 	})

--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -14,13 +14,7 @@ func CloseAllConnections() {
 
 func closeMatch(filter func(conn C.Connection) bool) {
 	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
-		if cc, ok := c.(C.Conn); ok {
-			if filter(cc) {
-				_ = c.Close()
-				return true
-			}
-		}
-		if cc, ok := c.(C.PacketConn); ok {
+		if cc, ok := c.(C.Connection); ok {
 			if filter(cc) {
 				_ = c.Close()
 				return true

--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -12,20 +12,26 @@ func CloseAllConnections() {
 	})
 }
 
-func closeMatch(filter func(conn C.Conn) bool) {
+func closeMatch(filter func(conn C.Connection) bool) {
 	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
 		if cc, ok := c.(C.Conn); ok {
 			if filter(cc) {
-				_ = cc.Close()
+				_ = c.Close()
 				return true
 			}
 		}
-		return false
+		if cc, ok := c.(C.PacketConn); ok {
+			if filter(cc) {
+				_ = c.Close()
+				return true
+			}
+		}
+		return true
 	})
 }
 
 func closeConnByGroup(name string) {
-	closeMatch(func(conn C.Conn) bool {
+	closeMatch(func(conn C.Connection) bool {
 		for _, c := range conn.Chains() {
 			if c == name {
 				return true


### PR DESCRIPTION
In `closeMatch`, the callback function returns `false` when the logic not getting into matching branch. This is not correct; as per `xsync.MapOf`, if the callback function `f` returns false, `Range` function stops the iteration. `f` should always return `true`.

Also considering at present the massive adoption of reliable byte-stream protocol based on UDP (QUIC by browsers, for example), `PacketConn`s should also be closed, if possible.