### PR TITLE
修复切换节点时打断连接没按代码的预期生效

### DIFF
--- a/core/src/main/golang/native/tunnel/conn.go
+++ b/core/src/main/golang/native/tunnel/conn.go
@@ -1,37 +1,37 @@
 package tunnel
 
 import (
-	C "github.com/metacubex/mihomo/constant"
-	"github.com/metacubex/mihomo/tunnel/statistic"
+    C "github.com/metacubex/mihomo/constant"
+    "github.com/metacubex/mihomo/tunnel/statistic"
 )
 
 func CloseAllConnections() {
-	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
-		_ = c.Close()
-		return true
-	})
+    statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
+        if conn, ok := c.(C.Conn); ok {
+            conn.Close()
+        }
+        return true
+    })
 }
 
 func closeMatch(filter func(conn C.Conn) bool) {
-	statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
-		if cc, ok := c.(C.Conn); ok {
-			if filter(cc) {
-				_ = cc.Close()
-				return true
-			}
-		}
-		return false
-	})
+    statistic.DefaultManager.Range(func(c statistic.Tracker) bool {
+        if conn, ok := c.(C.Conn); ok {
+            if filter(conn) {
+                conn.Close()
+            }
+        }
+        return true
+    })
 }
 
 func closeConnByGroup(name string) {
-	closeMatch(func(conn C.Conn) bool {
-		for _, c := range conn.Chains() {
-			if c == name {
-				return true
-			}
-		}
-
-		return false
-	})
+    closeMatch(func(conn C.Conn) bool {
+        for _, c := range conn.Chains() {
+            if c == name {
+                return true
+            }
+        }
+        return false
+    })
 }


### PR DESCRIPTION
- 增加调用 ` c.Close()` 的前置检查和转换，改为 type assertion `c.(C.Conn)`
- 修复 `statistic.Tracker` 类型没有 `Close()` 方法时无法正常工作，最终原代码的关闭连接行为失效
![Snipaste_2024-07-29_04-59-39](https://github.com/user-attachments/assets/03422df4-428f-4b1b-85bd-dac1cc2a3af1)
![Snipaste_2024-07-29_05-02-01](https://github.com/user-attachments/assets/9e830a5f-2bb0-43d9-96b9-3029313e2fed)

经测试，编译后在 Andorid 12 上正常运行，已按原代码预期行为生效，切换节点后立刻打断连接实时生效新节点
编译成品 app 测试：
https://dl.0z.gs/d/temp/cmfa-alpha-2.10.2_fixBreakConnect.zip?sign=hWitMWFflZoABM0LC5oZJEs25GogGa9LSBgqVUXNyi0=:0
