### PR TITLE
fix: discard settings for external controller in profiles

### DIFF
--- a/core/src/main/golang/native/config/process.go
+++ b/core/src/main/golang/native/config/process.go
@@ -17,6 +17,7 @@ import (
 )
 
 var processors = []processor{
+	patchExternalController,
 	patchOverride,
 	patchGeneral,
 	patchProfile,
@@ -27,6 +28,15 @@ var processors = []processor{
 }
 
 type processor func(cfg *config.RawConfig, profileDir string) error
+
+func patchExternalController(cfg *config.RawConfig, _ string) error {
+	cfg.ExternalController = ""
+	cfg.ExternalControllerTLS = ""
+	cfg.ExternalControllerUnix = ""
+	cfg.Secret = ""
+
+	return nil
+}
 
 func patchOverride(cfg *config.RawConfig, _ string) error {
 	if err := json.NewDecoder(strings.NewReader(ReadOverride(OverrideSlotPersist))).Decode(cfg); err != nil {

--- a/core/src/main/java/com/github/kr328/clash/core/model/ConfigurationOverride.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/ConfigurationOverride.kt
@@ -42,7 +42,7 @@ data class ConfigurationOverride(
     var ipv6: Boolean? = null,
 
     @SerialName("external-controller")
-    var externalController: String? = "127.0.0.1:0",
+    var externalController: String? = null,
 
     @SerialName("secret")
     var secret: String? = null,


### PR DESCRIPTION
Profiles can contain insecure settings for external controllers, and having a default value in `ConfigurationOverride` didn't help because they wouldn't be serialized (https://github.com/MetaCubeX/ClashMetaForAndroid/pull/299#issuecomment-2341219886). This PR disables the external controller in the original profile before the override is applied, so that only the explicit override settings are retained.