### PR TITLE
Modify log file saving location to external storage.

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/LogsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/LogsActivity.kt
@@ -60,7 +60,7 @@ class LogsActivity : BaseActivity<LogsDesign>() {
     }
 
     private fun loadFiles(): List<LogFile> {
-        val list = cacheDir.resolve("logs").listFiles()?.toList() ?: emptyList()
+        val list = logsDir.listFiles()?.toList() ?: emptyList()
 
         return list.mapNotNull { LogFile.parseFromFileName(it.name) }
     }

--- a/app/src/main/java/com/github/kr328/clash/util/Files.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/Files.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import java.io.File
 
 val Context.logsDir: File
-    get() = cacheDir.resolve("logs")
+    get() = getExternalFilesDir(null)?.resolve("logs") ?: cacheDir.resolve("logs")
 
 val Context.clashDir: File
     get() = filesDir.resolve("clash")


### PR DESCRIPTION
Modify log file saving location to external storage.

* Change `logsDir` in `Files.kt` to use external storage directory if available, otherwise fallback to internal storage.
* Update `LogsActivity.kt` to use `logsDir` for loading log files instead of `cacheDir`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MetaCubeX/ClashMetaForAndroid/pull/417?shareId=57cf2db1-3291-4e89-9d60-69f4e6d0f401).