### PR TITLE
Hide update notification

### DIFF
--- a/design/src/main/res/values-vi/strings.xml
+++ b/design/src/main/res/values-vi/strings.xml
@@ -112,7 +112,6 @@
     <string name="format_provider_type">%1$s(%2$s)</string>
     <string name="format_traffic_forwarded">%s được sử dụng</string>
     <string name="format_type_unsaved">%s (Chưa lưu)</string>
-    <string name="format_update_complete">Cập nhật %s thành công</string>
     <string name="format_update_failure">Cập nhật %1$s: %2$s</string>
     <string name="format_update_provider_failure">Cập nhật %1$s: %2$s</string>
     <string name="format_years_ago">%d năm trước</string>

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileWorker.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileWorker.kt
@@ -87,7 +87,7 @@ class ProfileWorker : BaseService() {
                 ProfileProcessor.update(this, imported.uuid, null)
             }
 
-            completed(imported.uuid, imported.name)
+            completed(imported.uuid)
 
             ProfileReceiver.scheduleNext(this, imported)
         } catch (e: Exception) {
@@ -169,17 +169,7 @@ class ProfileWorker : BaseService() {
             .setGroup(RESULT_CHANNEL)
     }
 
-    private fun completed(uuid: UUID, name: String) {
-        val id = UndefinedIds.next()
-
-        val notification = resultBuilder(id, uuid)
-            .setContentTitle(getString(R.string.update_successfully))
-            .setContentText(getString(R.string.format_update_complete, name))
-            .build()
-
-        NotificationManagerCompat.from(this)
-            .notify(id, notification)
-
+    private fun completed(uuid: UUID) {
         sendProfileUpdateCompleted(uuid)
     }
 

--- a/service/src/main/res/values-ja-rJP/strings.xml
+++ b/service/src/main/res/values-ja-rJP/strings.xml
@@ -6,7 +6,6 @@
     <string name="profile_process_result">プロファイルプロセスの結果</string>
     <string name="update_successfully">正常に更新されました</string>
     <string name="update_failure">更新に失敗しました</string>
-    <string name="format_update_complete">%sを更新しました</string>
     <string name="format_update_failure">更新 %1$s: %2$s </string>
     <string name="running">実行中</string>
     <string name="loading">読み込み中</string>

--- a/service/src/main/res/values-ko-rKR/strings.xml
+++ b/service/src/main/res/values-ko-rKR/strings.xml
@@ -6,7 +6,6 @@
     <string name="profile_process_result">구성 파일 처리 결과</string>
     <string name="update_successfully">업데이트 성공</string>
     <string name="update_failure">업데이트 실패</string>
-    <string name="format_update_complete">%s 업데이트 성공</string>
     <string name="format_update_failure">업데이트 %1$s: %2$s</string>
     <string name="running">연결됨</string>
     <string name="loading">로딩중</string>

--- a/service/src/main/res/values-ru/strings.xml
+++ b/service/src/main/res/values-ru/strings.xml
@@ -8,7 +8,6 @@
     <string name="profile_process_result">Результат обработки профиля</string>
     <string name="update_successfully">Успешно обновлено</string>
     <string name="update_failure">Не удалось обновить</string>
-    <string name="format_update_complete">Обновление %s завершено</string>
     <string name="format_update_failure">Обновление %1$s: %2$s</string>
     <string name="running">Работает</string>
     <string name="loading">Загружается</string>

--- a/service/src/main/res/values-zh-rHK/strings.xml
+++ b/service/src/main/res/values-zh-rHK/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="clash_service_status_channel">Clash 狀態</string>
     <string name="running">正在運行</string>
-    <string name="format_update_complete">更新 %s 成功</string>
     <string name="format_update_failure">"更新 %1$s: %2$s "</string>
     <string name="clash_meta_for_android">Clash Meta for Android</string>
     <string name="profiles_and_providers">配置文件和外部資源</string>

--- a/service/src/main/res/values-zh-rTW/strings.xml
+++ b/service/src/main/res/values-zh-rTW/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="clash_service_status_channel">Clash 狀態</string>
     <string name="running">正在運作</string>
-    <string name="format_update_complete">更新 %s 成功</string>
     <string name="format_update_failure">"更新 %1$s: %2$s "</string>
     <string name="clash_meta_for_android">Clash Meta for Android</string>
     <string name="profiles_and_providers">設定檔和外部資源</string>

--- a/service/src/main/res/values-zh/strings.xml
+++ b/service/src/main/res/values-zh/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="clash_service_status_channel">Clash 状态</string>
     <string name="running">正在运行</string>
-    <string name="format_update_complete">更新 %s 成功</string>
     <string name="format_update_failure">"更新 %1$s: %2$s "</string>
     <string name="clash_meta_for_android">Clash Meta for Android</string>
     <string name="profiles_and_providers">配置文件和外部资源</string>

--- a/service/src/main/res/values/strings.xml
+++ b/service/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="profile_process_result">Profile Process Result</string>
     <string name="update_successfully">Update Successfully</string>
     <string name="update_failure">Update Failure</string>
-    <string name="format_update_complete">Update %s completed</string>
     <string name="format_update_failure">Update %1$s: %2$s</string>
     <string name="running">Running</string>
     <string name="loading">Loading</string>


### PR DESCRIPTION
Constant “Profile updated” notifications can be annoying to the user. Especially if they have set themselves some kind of auto-update interval.

It seems to make sense to only show notifications for unsuccessful updates.