### PR TITLE
fix broadcast receiver not registered when application started with no ui, e.g. from settings tile or external control

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/remote/Broadcasts.kt
+++ b/app/src/main/java/com/github/kr328/clash/remote/Broadcasts.kt
@@ -100,6 +100,7 @@ class Broadcasts(private val context: Application) {
             })
 
             clashRunning = StatusClient(context).currentProfile() != null
+            registered = true
         } catch (e: Exception) {
             Log.w("Register global receiver: $e", e)
         }
@@ -113,6 +114,7 @@ class Broadcasts(private val context: Application) {
             context.unregisterReceiver(broadcastReceiver)
 
             clashRunning = false
+            registered = false
         } catch (e: Exception) {
             Log.w("Unregister global receiver: $e", e)
         }

--- a/app/src/main/java/com/github/kr328/clash/remote/Remote.kt
+++ b/app/src/main/java/com/github/kr328/clash/remote/Remote.kt
@@ -30,16 +30,16 @@ object Remote {
     fun launch() {
         ApplicationObserver.attach(Global.application)
 
+        broadcasts.register()
+
         ApplicationObserver.onVisibleChanged {
             if(it) {
                 Log.d("App becomes visible")
                 service.bind()
-                broadcasts.register()
             }
             else {
                 Log.d("App becomes invisible")
                 service.unbind()
-                broadcasts.unregister()
             }
         }
 


### PR DESCRIPTION
fixes #421 

The broadcast receiver should not be unregistered when the App becomes invisible since it still needs to listen to Intents.ACTION_CLASH_STARTED
Intents.ACTION_CLASH_STOPPED
to correctly update clashRunning state.
However, Broadcasts.registered was never updated to true so the unregister function never acctually took effect.

The problem is that when the App is started without ui, it never became visible, so the Broadcast receiever wasn't registered at all.