### PR TITLE
Fix crash when Hide App Icon is enabled alongside dynamic shortcuts

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/AppSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/AppSettingsActivity.kt
@@ -2,6 +2,7 @@ package com.github.kr328.clash
 
 import android.content.ComponentName
 import android.content.pm.PackageManager
+import androidx.core.content.pm.ShortcutManagerCompat
 import com.github.kr328.clash.common.util.componentName
 import com.github.kr328.clash.design.AppSettingsDesign
 import com.github.kr328.clash.design.model.Behavior
@@ -73,5 +74,9 @@ class AppSettingsActivity : BaseActivity<AppSettingsDesign>(), Behavior {
             newState,
             PackageManager.DONT_KILL_APP
         )
+        if (hide) {
+            // Prevent launcher activity not found.
+            ShortcutManagerCompat.removeAllDynamicShortcuts(this)
+        }
     }
 }

--- a/app/src/main/java/com/github/kr328/clash/MainApplication.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainApplication.kt
@@ -1,8 +1,10 @@
 package com.github.kr328.clash
 
 import android.app.Application
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -43,6 +45,16 @@ class MainApplication : Application() {
     }
 
     private fun setupShortcuts() {
+        val aliasState = packageManager.getComponentEnabledSetting(
+            ComponentName(this, mainActivityAlias)
+        )
+        if (aliasState != PackageManager.COMPONENT_ENABLED_STATE_ENABLED &&
+            aliasState != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+        ) {
+            ShortcutManagerCompat.removeAllDynamicShortcuts(this)
+            return
+        }
+
         val icon = IconCompat.createWithResource(this, R.mipmap.ic_launcher)
         val flags = Intent.FLAG_ACTIVITY_NEW_TASK or
             Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or


### PR DESCRIPTION
- Follow up #676.
- Fixes
  ```FATAL EXCEPTION: main
  Process: com.github.metacubex.clash.meta, PID: 11066
  java.lang.RuntimeException: Unable to create application com.github.kr328.clash.MainApplication
    at android.app.ActivityThread.handleBindApplication(ActivityThread.java:8144)
    at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2690)
    at android.os.Handler.dispatchMessage(Handler.java:132)
    at android.os.Looper.dispatchMessage(Looper.java:333)
    at android.os.Looper.loopOnce(Looper.java:263)
    at android.os.Looper.loop(Looper.java:367)
    at android.app.ActivityThread.main(ActivityThread.java:9287)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
  Caused by: java.lang.IllegalStateException: Launcher activity not found for package com.github.metacubex.clash.meta
    at android.os.Parcel.createExceptionOrNull(Parcel.java:3381)
    at android.os.Parcel.createException(Parcel.java:3357)
    at android.os.Parcel.readException(Parcel.java:3340)
    at android.os.Parcel.readException(Parcel.java:3282)
    at android.content.pm.IShortcutService$Stub$Proxy.setDynamicShortcuts(IShortcutService.java:599)
    at android.content.pm.ShortcutManager.setDynamicShortcuts(ShortcutManager.java:152)
    at androidx.core.content.pm.ShortcutManagerCompat.setDynamicShortcuts(ShortcutManagerCompat.java:473)
    at com.github.kr328.clash.MainApplication.setupShortcuts(MainApplication.kt:87)
    at com.github.kr328.clash.MainApplication.onCreate(MainApplication.kt:39)
    at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1396)
    at android.app.ActivityThread.handleBindApplication(ActivityThread.java:8139)
    ... 10 more
  ```