### PR TITLE
Derive states from MainActivity alias enabled

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/AppSettingsActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/AppSettingsActivity.kt
@@ -6,6 +6,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import com.github.kr328.clash.common.util.componentName
 import com.github.kr328.clash.design.AppSettingsDesign
 import com.github.kr328.clash.design.model.Behavior
+import com.github.kr328.clash.design.store.UiStore.Companion.mainActivityAlias
 import com.github.kr328.clash.service.store.ServiceStore
 import com.github.kr328.clash.util.ApplicationObserver
 import kotlinx.coroutines.isActive
@@ -70,7 +71,7 @@ class AppSettingsActivity : BaseActivity<AppSettingsDesign>(), Behavior {
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED
         }
         packageManager.setComponentEnabledSetting(
-            ComponentName(this, mainActivityAlias),
+            mainActivityAlias,
             newState,
             PackageManager.DONT_KILL_APP
         )

--- a/app/src/main/java/com/github/kr328/clash/MainActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainActivity.kt
@@ -159,5 +159,3 @@ class MainActivity : BaseActivity<MainDesign>() {
         }
     }
 }
-
-val mainActivityAlias = "${MainActivity::class.java.name}Alias"

--- a/app/src/main/java/com/github/kr328/clash/MainApplication.kt
+++ b/app/src/main/java/com/github/kr328/clash/MainApplication.kt
@@ -1,10 +1,8 @@
 package com.github.kr328.clash
 
 import android.app.Application
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -12,6 +10,7 @@ import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.common.compat.currentProcessName
 import com.github.kr328.clash.common.constants.Intents
 import com.github.kr328.clash.common.log.Log
+import com.github.kr328.clash.design.store.UiStore
 import com.github.kr328.clash.remote.Remote
 import com.github.kr328.clash.service.util.sendServiceRecreated
 import com.github.kr328.clash.util.clashDir
@@ -22,6 +21,8 @@ import com.github.kr328.clash.design.R as DesignR
 
 @Suppress("unused")
 class MainApplication : Application() {
+    private val uiStore by lazy(LazyThreadSafetyMode.NONE) { UiStore(this) }
+
     override fun attachBaseContext(base: Context?) {
         super.attachBaseContext(base)
 
@@ -45,12 +46,8 @@ class MainApplication : Application() {
     }
 
     private fun setupShortcuts() {
-        val aliasState = packageManager.getComponentEnabledSetting(
-            ComponentName(this, mainActivityAlias)
-        )
-        if (aliasState != PackageManager.COMPONENT_ENABLED_STATE_ENABLED &&
-            aliasState != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
-        ) {
+        if (uiStore.hideAppIcon) {
+            // Prevent launcher activity not found.
             ShortcutManagerCompat.removeAllDynamicShortcuts(this)
             return
         }

--- a/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/store/UiStore.kt
@@ -1,6 +1,8 @@
 package com.github.kr328.clash.design.store
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import com.github.kr328.clash.common.store.Store
 import com.github.kr328.clash.common.store.asStoreProvider
 import com.github.kr328.clash.core.model.ProxySort
@@ -27,7 +29,11 @@ class UiStore(context: Context) {
 
     var hideAppIcon: Boolean by store.boolean(
         key = "hide_app_icon",
-        defaultValue = false
+        defaultValue = context.packageManager.getComponentEnabledSetting(context.mainActivityAlias)
+            .let { state ->
+                state != PackageManager.COMPONENT_ENABLED_STATE_ENABLED &&
+                        state != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+            },
     )
 
     var hideFromRecents: Boolean by store.boolean(
@@ -74,5 +80,8 @@ class UiStore(context: Context) {
 
     companion object {
         private const val PREFERENCE_NAME = "ui"
+
+        val Context.mainActivityAlias: ComponentName
+            get() = ComponentName(this, "com.github.kr328.clash.MainActivityAlias")
     }
 }


### PR DESCRIPTION
`hideAppIcon` defaulted to `false` regardless of the actual `MainActivityAlias` component state, causing the setting UI to show "not hidden" even when the alias was already disabled.