### PR TITLE
Fix clash:// deep link not opening app due to premature Activity finish

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -49,6 +49,7 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
                     startActivity(PropertiesActivity::class.intent.setUUID(uuid))
                     finish()
                 }
+                return
             }
 
             Intents.ACTION_TOGGLE_CLASH -> if(Remote.broadcasts.clashRunning) {


### PR DESCRIPTION
Problem                                                                                                                                                                                                
                                                                                                                                                                                                         
When opening a clash://install-config?url=... deep link, the app would flash briefly or appear to not open at all.                                                                                     

Root Cause

In ExternalControlActivity.onCreate(), the ACTION_VIEW branch launches an async coroutine to create the profile and then start PropertiesActivity. However, after the when block, there is an unconditional return finish() at the end of onCreate(). Since launch {} returns immediately, the Activity was being destroyed before the coroutine completed — causing startActivity() to be called on an already-finished Activity.

Fix

Added a return statement after the launch {} block in the ACTION_VIEW branch to prevent execution from falling through to the premature finish(). The coroutine now manages the Activity lifecycle itself, calling finish() after startActivity() succeeds.
