### PR TITLE
Fix parse profile-update-interval http header

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ExternalControlActivity.kt
@@ -42,8 +42,12 @@ class ExternalControlActivity : Activity(), CoroutineScope by MainScope() {
                         }
                         val name = uri.getQueryParameter("name") ?: getString(R.string.new_profile)
 
+                        val parsedInterval = uri.getQueryParameter("update-interval")?.toLongOrNull() ?: 0L
+                        val updateInterval = if (parsedInterval > 0) parsedInterval.coerceAtLeast(15L) else 0L
+                        val intervalMs = java.util.concurrent.TimeUnit.MINUTES.toMillis(updateInterval)
+
                         create(type, name).also {
-                            patch(it, name, url, 0)
+                            patch(it, name, url, intervalMs)
                         }
                     }
                     startActivity(PropertiesActivity::class.intent.setUUID(uuid))

--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -73,6 +73,7 @@ object ProfileProcessor {
                         var download: Long = 0
                         var total: Long = 0
                         var expire: Long = 0
+                        var updateInterval: Long = snapshot.interval
                         if (snapshot?.type == Profile.Type.Url) {
                             if (snapshot.source.startsWith("https://", true)) {
                                 val client = OkHttpClient()
@@ -103,6 +104,19 @@ object ProfileProcessor {
                                             }
                                         }
                                     }
+
+                                    val updateIntervalHeader = response.headers["profile-update-interval"]
+                                    if (response.isSuccessful && updateIntervalHeader != null) {
+                                        val intervalHours = updateIntervalHeader.toLongOrNull()
+                                        if (intervalHours != null) {
+                                            updateInterval = if (intervalHours > 0) {
+                                                java.util.concurrent.TimeUnit.HOURS.toMillis(intervalHours)
+                                                    .coerceAtLeast(java.util.concurrent.TimeUnit.MINUTES.toMillis(15))
+                                            } else {
+                                                0L
+                                            }
+                                        }
+                                    }
                                 }
                             }
                             val new = Imported(
@@ -110,7 +124,7 @@ object ProfileProcessor {
                                 snapshot.name,
                                 snapshot.type,
                                 snapshot.source,
-                                snapshot.interval,
+                                updateInterval,
                                 upload,
                                 download,
                                 total,


### PR DESCRIPTION
Currently, when importing a profile via the clash(meta)://install-config intent, the application hardcodes the update interval to 0. It also ignores the standard Profile-Update-Interval HTTP header, leaving auto-updates disabled by default.

Fixes:
- Parse Profile-Update-Interval HTTP header (in hours) on fetch;
- Parse update-interval URI param (in minutes) from intents;
- Enforce a 15 min minimum bound to prevent server DDoS;
- Safely handle malformed inputs and allow <= 0 to explicitly disable updates.