### PR TITLE
Add unique cmfa:// deeplink to avoid scheme collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ APP package name is `com.github.metacubex.clash.meta`
 - Stop Clash.Meta service
   - Send intent to activity `com.github.kr328.clash.ExternalControlActivity` with action `com.github.metacubex.clash.meta.action.STOP_CLASH`
 - Import a profile
-  - URL Scheme `clash://install-config?url=<encoded URI>` or `clashmeta://install-config?url=<encoded URI>`
+  - URL Scheme `clash://install-config?url=<encoded URI>`, `clashmeta://install-config?url=<encoded URI>` or `cmfa://install-config?url=<encoded URI>`
 
 ### Contribution and Project Maintenance
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
 
                 <data android:scheme="clash"/>
                 <data android:scheme="clashmeta"/>
+                <data android:scheme="cmfa"/>
                 <data android:host="install-config"/>
             </intent-filter>
             <intent-filter>


### PR DESCRIPTION
Generic schemes like clash:// and clashmeta:// are often intercepted by other clients (e.g., Hiddify, ClClash), triggering the Android app selection dialog if multiple clients are installed.

This PR introduces an additional cmfa:// scheme.
It allows subscription providers to use cmfa://install-config?url=... to bypass the app chooser and strictly open Clash Meta For Android.

Existing clash:// and clashmeta:// schemes remain untouched.