### PR TITLE
fix profile can not be selected by remote controller on android tv

### DIFF
--- a/design/src/main/res/layout/adapter_profile.xml
+++ b/design/src/main/res/layout/adapter_profile.xml
@@ -26,6 +26,7 @@
         android:layout_marginVertical="5dp"
         android:layout_marginHorizontal="@dimen/item_header_margin"
         android:background="@drawable/bg_b"
+        android:foreground="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
         android:minHeight="@dimen/item_min_height"


### PR DESCRIPTION
on amazon firetv stick, remote controller can not select the profile, can not focus on the profile item