### PR TITLE
fix(profile): prevent HTTP header from overriding custom update intervals

### DIFF
--- a/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/ProfileProcessor.kt
@@ -106,7 +106,7 @@ object ProfileProcessor {
                                     }
 
                                     val updateIntervalHeader = response.headers["profile-update-interval"]
-                                    if (response.isSuccessful && updateIntervalHeader != null) {
+                                    if (old == null && snapshot.interval == 0L && response.isSuccessful && updateIntervalHeader != null) {
                                         val intervalHours = updateIntervalHeader.toLongOrNull()
                                         if (intervalHours != null) {
                                             updateInterval = if (intervalHours > 0) {


### PR DESCRIPTION
Fixes #751

**Bug:** 
If a user manually changed the auto-update interval in the app, the server's `profile-update-interval` HTTP header would immediately overwrite their choice during the next fetch.

**Fix:** 
The HTTP header is now only applied to completely new profiles during the initial import. Manual changes made by the user will no longer be overwritten.