### PR TITLE
ci: add GitHub Artifact Attestations (build provenance)

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   BuildDebug:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -69,7 +73,12 @@ jobs:
       - name: Build
         if: success()
         run: ./gradlew --no-daemon app:assembleAlphaRelease
-          
+
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: app/build/outputs/apk/alpha/release/*.apk
+
       - name: Upload Aritfact (universal)
         uses: actions/upload-artifact@v7
         if: ${{  success() }}

--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -10,10 +10,6 @@ on:
 jobs:
   BuildDebug:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -73,11 +69,6 @@ jobs:
       - name: Build
         if: success()
         run: ./gradlew --no-daemon app:assembleAlphaRelease
-
-      - name: Generate Artifact Attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: app/build/outputs/apk/alpha/release/*.apk
 
       - name: Upload Aritfact (universal)
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-pre-release.yaml
+++ b/.github/workflows/build-pre-release.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   BuildPreRelease:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -67,6 +71,11 @@ jobs:
       - name: Pre-release Build
         if: success()
         run: ./gradlew --no-daemon app:assembleAlphaRelease
+
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: app/build/outputs/apk/alpha/release/*.apk
 
       # Delete old Prerelease-alpha
       - uses: dev-drprasad/delete-tag-and-release@v1.1

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   BuildRelease:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -106,6 +110,11 @@ jobs:
       - name: Release Build
         if: success()
         run: ./gradlew --no-daemon app:assembleMetaRelease
+
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: app/build/outputs/apk/meta/release/*.apk
 
       - name: Tag Repo
         uses: richardsimko/update-tag@v1


### PR DESCRIPTION
## Summary

This PR integrates GitHub Artifact Attestations (build provenance) into the release workflows.

As a security-sensitive project, the trustworthiness of released artifacts is critical. Provenance attestation attaches a cryptographically signed, verifiable proof of origin to each build artifact. Verifiers can confirm that the APKs were built by this repository, from a specific workflow and commit, inside GitHub-hosted Actions runners — not manually replaced or produced by an unknown build environment.

The recent **Linux xz backdoor incident** is a textbook example: the source code was clean, but the distributed pre-compiled binaries were poisoned. This illustrates that the trust chain doesn't end at the source code — it extends all the way to the actual built, packaged, and distributed artifacts. Provenance provides exactly this kind of "origin verifiability", helping downstream users confirm that what they received came from the expected official build pipeline.

## Changes

- Added `permissions: id-token: write, attestations: write, contents: write` to `BuildRelease` and `BuildPreRelease` jobs
- Added `actions/attest-build-provenance@v2` step after each build step to generate signed attestations for all output APKs

## Verification

Once a release is built, anyone can verify an APK with:

```bash
gh attestation verify <apk-file> --repo MetaCubeX/ClashMetaForAndroid
```