### PR TITLE
AndroidManifest.xml: add INTERACT_ACROSS_USERS permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
+    <!-- Workaround for Android 17+ cross profile loopback networking restrictions.
+         This permission allows CMFA to connect to loopback addresses and ports bound
+         by the same app running in different profiles.
+         It can only be granted via ADB. -->
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS"
         tools:ignore="ProtectedPermissions" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:name=".MainApplication"


### PR DESCRIPTION
Android 17 blocks cross profile loopback network traffic by default. VPN in secondary profiles can no longer simply route everything to the listening port of CMFA in the primary profile; instead a complex config must be individually maintained in each profile.

Per VentralDigital/InterProfileSharing#34, the `INTERACT_ACROSS_USERS` permission, when manually granted with ADB, allows cross profile traffic at least for the same app.

Adding this permission won't affect existing users as it must be manually enabled via ADB.