### PR TITLE
fix(security): harden local control boundaries

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/remote/Broadcasts.kt
+++ b/app/src/main/java/com/github/kr328/clash/remote/Broadcasts.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import com.github.kr328.clash.common.compat.registerReceiverCompat
 import com.github.kr328.clash.common.constants.Intents
+import com.github.kr328.clash.common.constants.Permissions
 import com.github.kr328.clash.common.log.Log
 import java.util.*
 
@@ -59,12 +60,16 @@ class Broadcasts(private val context: Application) {
                 Intents.ACTION_PROFILE_UPDATE_COMPLETED ->
                     receivers.forEach {
                         it.onProfileUpdateCompleted(
-                            UUID.fromString(intent.getStringExtra(Intents.EXTRA_UUID)))
+                            intent.getStringExtra(Intents.EXTRA_UUID)?.let {
+                                runCatching { UUID.fromString(it) }.getOrNull()
+                            })
                     }
                 Intents.ACTION_PROFILE_UPDATE_FAILED ->
                     receivers.forEach {
                         it.onProfileUpdateFailed(
-                            UUID.fromString(intent.getStringExtra(Intents.EXTRA_UUID)),
+                            intent.getStringExtra(Intents.EXTRA_UUID)?.let {
+                                runCatching { UUID.fromString(it) }.getOrNull()
+                            },
                             intent.getStringExtra(Intents.EXTRA_FAIL_REASON))
                     }
                 Intents.ACTION_PROFILE_LOADED -> {
@@ -89,15 +94,20 @@ class Broadcasts(private val context: Application) {
             return
 
         try {
-            context.registerReceiverCompat(broadcastReceiver, IntentFilter().apply {
-                addAction(Intents.ACTION_SERVICE_RECREATED)
-                addAction(Intents.ACTION_CLASH_STARTED)
-                addAction(Intents.ACTION_CLASH_STOPPED)
-                addAction(Intents.ACTION_PROFILE_CHANGED)
-                addAction(Intents.ACTION_PROFILE_UPDATE_COMPLETED)
-                addAction(Intents.ACTION_PROFILE_UPDATE_FAILED)
-                addAction(Intents.ACTION_PROFILE_LOADED)
-            })
+            context.registerReceiverCompat(
+                broadcastReceiver,
+                IntentFilter().apply {
+                    addAction(Intents.ACTION_SERVICE_RECREATED)
+                    addAction(Intents.ACTION_CLASH_STARTED)
+                    addAction(Intents.ACTION_CLASH_STOPPED)
+                    addAction(Intents.ACTION_PROFILE_CHANGED)
+                    addAction(Intents.ACTION_PROFILE_UPDATE_COMPLETED)
+                    addAction(Intents.ACTION_PROFILE_UPDATE_FAILED)
+                    addAction(Intents.ACTION_PROFILE_LOADED)
+                },
+                Permissions.RECEIVE_SELF_BROADCASTS,
+                null,
+            )
 
             clashRunning = StatusClient(context).currentProfile() != null
         } catch (e: Exception) {

--- a/core/src/main/golang/native/config/process.go
+++ b/core/src/main/golang/native/config/process.go
@@ -44,6 +44,11 @@ func patchOverride(cfg *config.RawConfig, _ string) error {
 func patchExternalController(cfg *config.RawConfig, _ string) error {
 	cfg.ExternalController = ""
 	cfg.ExternalControllerTLS = ""
+	cfg.ExternalControllerUnix = ""
+	cfg.ExternalControllerPipe = ""
+	cfg.ExternalControllerCors = config.RawCors{}
+	cfg.Secret = ""
+	cfg.DNS.Listen = ""
 
 	return nil
 }

--- a/core/src/main/golang/native/config/process_test.go
+++ b/core/src/main/golang/native/config/process_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"testing"
+
+	mihomoConfig "github.com/metacubex/mihomo/config"
+)
+
+func TestPatchExternalControllerStripsProfileSecurityState(t *testing.T) {
+	cfg := &mihomoConfig.RawConfig{
+		ExternalController:     "0.0.0.0:9090",
+		ExternalControllerTLS:  "0.0.0.0:9443",
+		ExternalControllerUnix: "/data/local/tmp/clash.sock",
+		ExternalControllerPipe: "clash-pipe",
+		ExternalControllerCors: mihomoConfig.RawCors{
+			AllowOrigins:        []string{"https://attacker.example"},
+			AllowPrivateNetwork: true,
+		},
+		Secret: "profile-controlled-secret",
+		DNS: mihomoConfig.RawDNS{
+			Enable: true,
+			Listen: ":1053",
+		},
+	}
+
+	if err := patchExternalController(cfg, ""); err != nil {
+		t.Fatalf("patchExternalController failed: %v", err)
+	}
+
+	if cfg.ExternalController != "" || cfg.ExternalControllerTLS != "" ||
+		cfg.ExternalControllerUnix != "" || cfg.ExternalControllerPipe != "" {
+		t.Fatal("profile-controlled external controller endpoint was preserved")
+	}
+	if len(cfg.ExternalControllerCors.AllowOrigins) != 0 || cfg.ExternalControllerCors.AllowPrivateNetwork {
+		t.Fatal("profile-controlled external controller CORS was preserved")
+	}
+	if cfg.Secret != "" {
+		t.Fatal("profile-controlled external controller secret was preserved")
+	}
+	if cfg.DNS.Listen != "" {
+		t.Fatal("profile-controlled DNS listener was preserved")
+	}
+}
+
+func TestPatchOverrideCanRestoreTrustedSecurityState(t *testing.T) {
+	cfg := &mihomoConfig.RawConfig{
+		ExternalController: "0.0.0.0:9090",
+		Secret:             "profile-controlled-secret",
+		DNS: mihomoConfig.RawDNS{
+			Enable: true,
+			Listen: ":1053",
+		},
+	}
+
+	if err := patchExternalController(cfg, ""); err != nil {
+		t.Fatalf("patchExternalController failed: %v", err)
+	}
+
+	WriteOverride(OverrideSlotSession, `{
+		"external-controller":"127.0.0.1:9090",
+		"external-controller-cors":{
+			"allow-origins":["https://dashboard.example"],
+			"allow-private-network":true
+		},
+		"secret":"trusted-secret",
+		"dns":{"listen":"127.0.0.1:1053"}
+	}`)
+	defer ClearOverride(OverrideSlotSession)
+
+	if err := patchOverride(cfg, ""); err != nil {
+		t.Fatalf("patchOverride failed: %v", err)
+	}
+
+	if cfg.ExternalController != "127.0.0.1:9090" || cfg.Secret != "trusted-secret" {
+		t.Fatal("trusted external controller override was not restored")
+	}
+	if len(cfg.ExternalControllerCors.AllowOrigins) != 1 ||
+		cfg.ExternalControllerCors.AllowOrigins[0] != "https://dashboard.example" ||
+		!cfg.ExternalControllerCors.AllowPrivateNetwork {
+		t.Fatal("trusted external controller CORS override was not restored")
+	}
+	if cfg.DNS.Listen != "127.0.0.1:1053" {
+		t.Fatal("trusted DNS listener override was not restored")
+	}
+}

--- a/service/src/main/java/com/github/kr328/clash/service/TunService.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/TunService.kt
@@ -221,7 +221,11 @@ class TunService : VpnService(), CoroutineScope by CoroutineScope(Dispatchers.De
                 stack = store.tunStackMode,
                 gateway = "$TUN_GATEWAY/$TUN_SUBNET_PREFIX" + if (store.allowIpv6) ",$TUN_GATEWAY6/$TUN_SUBNET_PREFIX6" else "",
                 portal = TUN_PORTAL + if (store.allowIpv6) ",$TUN_PORTAL6" else "",
-                dns = if (store.dnsHijacking) NET_ANY else (TUN_DNS + if (store.allowIpv6) ",$TUN_DNS6" else ""),
+                dns = if (store.dnsHijacking) {
+                    NET_ANY + if (store.allowIpv6) ",$NET_ANY6" else ""
+                } else {
+                    TUN_DNS + if (store.allowIpv6) ",$TUN_DNS6" else ""
+                },
             )
         }
 


### PR DESCRIPTION
## Summary

- clear profile-controlled external controller endpoints, CORS, secret, and `dns.listen` before applying trusted app overrides
- include the IPv6 wildcard in DNS hijacking when IPv6 is enabled
- require the existing signature permission for app-internal broadcasts and tolerate malformed UUID extras
- add regression coverage for both stripping untrusted profile state and restoring explicit trusted overrides

## Security rationale

The native config pipeline already clears `external-controller` before applying app-owned overrides, but related fields remained sourced from the subscription. A profile could therefore supply permissive CORS, a known controller secret, or a wildcard DNS listener that became active when the user enabled the related feature through trusted settings.

This change treats those fields as one trust boundary: profile values are removed first, then persisted/session overrides may explicitly restore user-controlled values. Same-origin controller UI behavior is unchanged; cross-origin access now requires an explicit trusted override instead of inheriting profile/default CORS.

The VPN path also advertised an IPv6 DNS server and route while `dnsHijacking` only supplied `0.0.0.0` to the native TUN layer. Adding `::` closes that IPv6 policy gap.

Finally, package-scoped broadcast actions were not sender authentication. Registering with the existing signature permission prevents other apps from spoofing internal state events; defensive UUID parsing avoids a crash if malformed state is ever received.

## Validation

- `git diff --check` — passed
- `./gradlew.bat --no-daemon app:assembleAlphaRelease` with JDK 21 and Android SDK — passed, including Kotlin, Go/native builds for all four ABIs, CMake, lintVital, R8, and APK packaging
- independent Codex reviewer pass — no code or security blockers found
- Go regression tests were added; standalone host execution is not available on Windows because the existing `native/platform` package is selected only for supported target environments

## Review provenance

Based on findings from **Codex Security** and prepared with the requested **Codex / GPT-5.6 Sol workflow**. This is AI-assisted security remediation, not a substitute for maintainer review.

**Human security review is explicitly requested before merge**, especially for controller override compatibility, Android broadcast behavior on pre-33 devices, and IPv6 DNS hijacking semantics.

## Risk / rollout notes

- explicit persisted/session overrides remain authoritative and are covered by the new regression test
- profiles can no longer open DNS/controller listeners or define controller authentication/CORS implicitly
- no database, permission declaration, dependency, or submodule revision changes
