### PR TITLE
build(security): verify Gradle distribution

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- pin the SHA-256 checksum for the Gradle 8.10.2 binary distribution used by the Wrapper

## Security rationale

The Gradle Wrapper executes before project build logic. Without `distributionSha256Sum`, the downloaded distribution is trusted solely through transport security. Gradle recommends setting this property so the Wrapper rejects a distribution whose bytes do not match the expected release artifact.

The checksum was retrieved directly from:

- https://services.gradle.org/distributions/gradle-8.10.2-bin.zip.sha256

Relevant Gradle guidance:

- https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification
- https://docs.gradle.org/current/userguide/best_practices_security.html

## Validation

- `gradlew.bat --version` — passed; resolved Gradle 8.10.2 on JDK 21
- `git diff --check` — passed
- pre-commit/PR static preflight — no findings

## Review provenance

Based on a **Codex Security** finding and prepared with the requested **Codex / GPT-5.6 Sol workflow**.

**Human review is explicitly requested before merge.** Please independently compare the checksum with Gradle's official release checksum.

## Risk / rollout notes

- one-line build-security change only
- no dependency, Wrapper JAR, application code, or submodule changes
