### PR TITLE
feat: Tailscale override (proxy node + MagicDNS routing + UI)

### DIFF
--- a/core/src/main/golang/native/config/process.go
+++ b/core/src/main/golang/native/config/process.go
@@ -10,6 +10,7 @@ import (
 
 	"cfa/native/common"
 
+	"github.com/metacubex/mihomo/common/orderedmap"
 	"github.com/metacubex/mihomo/common/utils"
 	"github.com/metacubex/mihomo/config"
 	C "github.com/metacubex/mihomo/constant"
@@ -19,6 +20,7 @@ import (
 var processors = []processor{
 	patchExternalController, // must before patchOverride, so we only apply ExternalController in Override settings
 	patchOverride,
+	patchTailscale, // expand override `tailscale` (single node + routing) into proxies/groups/rules
 	patchGeneral,
 	patchProfile,
 	patchDns,
@@ -39,6 +41,174 @@ func patchOverride(cfg *config.RawConfig, _ string) error {
 	}
 
 	return nil
+}
+
+// tailscaleOverride mirrors the flat `tailscale` object the Kotlin app writes
+// into the override JSON. json tags match the kotlinx serialization output
+// (property names, since the Kotlin data class has no @SerialName annotations).
+type tailscaleOverride struct {
+	Enabled    bool     `json:"enabled"`
+	Hostname   string   `json:"hostname,omitempty"`
+	AuthKey    string   `json:"authKey,omitempty"`
+	ControlURL string   `json:"controlUrl,omitempty"`
+	StateDir   string   `json:"stateDir,omitempty"`
+	ExitNode   string   `json:"exitNode,omitempty"`
+	IpCidrs    []string `json:"ipCidrs"`
+}
+
+type tailscaleOverrideEnvelope struct {
+	Tailscale tailscaleOverride `json:"tailscale"`
+}
+
+// loadTailscaleOverride parses the tailscale block from the persist override
+// JSON. It is a pure function (no file I/O) so it can be unit-tested directly;
+// callers pass ReadOverride(OverrideSlotPersist). The bool result reports
+// whether tailscale is enabled. A single `enabled` toggle (rather than "any
+// field non-empty") lets the user keep a fully-default node — e.g. after
+// clearing a one-time auth-key while still using the persistent state dir, or
+// relying on tsnet's interactive login with no options at all.
+func loadTailscaleOverride(overrideJSON string) (tailscaleOverride, bool) {
+	var envelope tailscaleOverrideEnvelope
+	if err := json.Unmarshal([]byte(overrideJSON), &envelope); err != nil {
+		log.Warnln("Apply tailscale override: %s", err.Error())
+		return tailscaleOverride{}, false
+	}
+	if !envelope.Tailscale.Enabled {
+		return tailscaleOverride{}, false
+	}
+	return envelope.Tailscale, true
+}
+
+// Fixed names for the injected tailscale proxy and its select group. They are
+// constants (not user-configurable) so they are always URL-safe in the
+// "tailscale://<name>" nameserver-policy and never collide with mihomo's
+// built-in proxy names (DIRECT/REJECT/...). A proxy and a group may NOT share
+// a name — mihomo registers both in one map (config.go proxies[...]) — hence
+// the distinct "-Group" suffix.
+const (
+	tailscaleProxyName = "Tailscale"
+	tailscaleGroupName = "Tailscale-Group"
+)
+
+// patchTailscale expands the override `tailscale` block into a proxy node, a
+// select group and prepend rules, all appended/prepended on top of the
+// subscription config. Keeping the expansion on the Go side lets the Kotlin
+// model stay a plain flat object (no custom serializer), which is safe for the
+// Android Parcel IPC path.
+//
+// Any same-named proxy/group already present in the subscription is removed
+// first, so re-applying the override (or a subscription that happens to define
+// its own "Tailscale") replaces rather than triggers mihomo's "duplicate name"
+// error. Both fixed names are cleared from BOTH cfg.Proxy and cfg.ProxyGroup,
+// because mihomo registers proxies and groups in one shared map — a group named
+// "Tailscale" would clash with our proxy even though we only append a group
+// named "Tailscale-Group", and vice versa.
+func patchTailscale(cfg *config.RawConfig, _ string) error {
+	ts, ok := loadTailscaleOverride(ReadOverride(OverrideSlotPersist))
+	if !ok {
+		return nil
+	}
+
+	removeProxyByName(cfg, tailscaleProxyName)
+	removeProxyGroupByName(cfg, tailscaleProxyName)
+	removeProxyByName(cfg, tailscaleGroupName)
+	removeProxyGroupByName(cfg, tailscaleGroupName)
+
+	// 1. append the tailscale proxy node. Only non-empty option fields are set
+	// so mihomo applies its own defaults for the rest.
+	proxy := map[string]any{
+		"name": tailscaleProxyName,
+		"type": "tailscale",
+	}
+	if ts.Hostname != "" {
+		proxy["hostname"] = ts.Hostname
+	}
+	if ts.AuthKey != "" {
+		proxy["auth-key"] = ts.AuthKey
+	}
+	if ts.ControlURL != "" {
+		proxy["control-url"] = ts.ControlURL
+	}
+	if ts.StateDir != "" {
+		proxy["state-dir"] = ts.StateDir
+	}
+	if ts.ExitNode != "" {
+		proxy["exit-node"] = ts.ExitNode
+	}
+	cfg.Proxy = append(cfg.Proxy, proxy)
+	log.Infoln("Append tailscale proxy: %s", tailscaleProxyName)
+
+	// 2. select group + prepend rules routing tailnet traffic to it.
+	//
+	// CMFA forces fake-ip mode. mihomo returns a synthetic IP for a name,
+	// then maps it back to the host on the connection; rules then match on
+	// that host. Two rules cover tailnet access:
+	//  - DOMAIN-SUFFIX,ts.net: all tailnet FQDNs (nas.tail<hex>.ts.net).
+	//    Tailscale short names (e.g. "nas") are NOT supported: the tsnet
+	//    QueryDNS path does not append the MagicDNS search suffix, so they
+	//    cannot be resolved. Users must use full *.ts.net names or IPs.
+	//  - IP-CIDR 100.64.0.0/10: the CGNAT range tailscale allocates from.
+	//
+	// Note: the +.ts.net fake-ip filter and the nameserver-policy are added in
+	// patchDns (below), not here, because patchDns runs AFTER patchTailscale
+	// and would otherwise reset cfg.DNS for subscriptions that don't enable
+	// their own DNS.
+	cfg.ProxyGroup = append(cfg.ProxyGroup, map[string]any{
+		"name":    tailscaleGroupName,
+		"type":    "select",
+		"proxies": []string{tailscaleProxyName},
+	})
+
+	// Default IP range: Tailscale allocates node IPs from the CGNAT block
+	// 100.64.0.0/10, which is identical for every tailnet.
+	ips := ts.IpCidrs
+	if len(ips) == 0 {
+		ips = []string{"100.64.0.0/10"}
+	}
+	rules := make([]string, 0, len(ips)+1)
+
+	// Cover all tailnet FQDNs (*.ts.net) automatically.
+	rules = append(rules, "DOMAIN-SUFFIX,ts.net,"+tailscaleGroupName)
+
+	// Direct IP access into the tailnet.
+	for _, c := range ips {
+		rules = append(rules, "IP-CIDR,"+c+","+tailscaleGroupName+",no-resolve")
+	}
+
+	merged := make([]string, 0, len(rules)+len(cfg.Rule))
+	merged = append(merged, rules...)
+	merged = append(merged, cfg.Rule...)
+	cfg.Rule = merged
+
+	log.Infoln("Apply tailscale routing: group=%s rules=%d", tailscaleGroupName, len(rules))
+
+	return nil
+}
+
+// removeProxyByName drops every proxy whose "name" equals name from cfg.Proxy.
+// Used to overwrite a same-named entry the subscription already ships before
+// appending our own, avoiding mihomo's "duplicate name" load error.
+func removeProxyByName(cfg *config.RawConfig, name string) {
+	filtered := cfg.Proxy[:0]
+	for _, p := range cfg.Proxy {
+		if n, _ := p["name"].(string); n == name {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	cfg.Proxy = filtered
+}
+
+// removeProxyGroupByName is the proxy-group counterpart of removeProxyByName.
+func removeProxyGroupByName(cfg *config.RawConfig, name string) {
+	filtered := cfg.ProxyGroup[:0]
+	for _, g := range cfg.ProxyGroup {
+		if n, _ := g["name"].(string); n == name {
+			continue
+		}
+		filtered = append(filtered, g)
+	}
+	cfg.ProxyGroup = filtered
 }
 
 func patchExternalController(cfg *config.RawConfig, _ string) error {
@@ -81,7 +251,84 @@ func patchDns(cfg *config.RawConfig, _ string) error {
 		cfg.DNS.NameServer = append(cfg.DNS.NameServer, "system://")
 	}
 
+	// Route *.ts.net to the Tailscale MagicDNS transport when tailscale is
+	// configured. This runs after the default/reset block above so it survives
+	// the DNS replacement for subscriptions without their own DNS.
+	if _, ok := loadTailscaleOverride(ReadOverride(OverrideSlotPersist)); ok {
+		applyTailscaleDNS(&cfg.DNS)
+	}
+
 	return nil
+}
+
+// tsPolicyKey / tsFilterEntry / tsFilterRule are the domain keys injected into
+// DNS policy and fake-ip-filter. The key form "+.ts.net" is accepted by both
+// parseNameServerPolicy (via ValidAndSplitDomain) and the fake-ip trie.
+const (
+	tsPolicyKey   = "+.ts.net"
+	tsFilterEntry = "+.ts.net"
+	// tsFilterRule is the rule-mode form of the same intent: a real-ip action so
+	// the domain is excluded from fake-ip. parseFakeIPRules requires an explicit
+	// action suffix; a bare "+.ts.net" would fail config parsing.
+	tsFilterRule = "DOMAIN-SUFFIX,ts.net,real-ip"
+)
+
+// applyTailscaleDNS wires *.ts.net to the registered tailscale:// DNS transport
+// and keeps the domain out of fake-ip. Both must be done for MagicDNS FQDNs to
+// resolve correctly:
+//
+//  1. nameserver-policy: mihomo only instantiates the tailscale DNS client when
+//     the scheme "tailscale://<node>" appears in a nameserver / policy slot.
+//     Without this entry the transport is registered but never queried, so FQDNs
+//     fall through to the system DNS and fail.
+//
+//  2. fake-ip-filter: the fake-ip middleware consults the skipper before any
+//     upstream, so an unlisted *.ts.net would get a synthetic IP and never reach
+//     the policy. The correct filter entry depends on the mode:
+//     - blacklist (default): "+.ts.net" is a skip entry → real DNS (the policy).
+//     - whitelist: only listed domains use fake-ip; since we don't list *.ts.net
+//     it is skipped out of fake-ip and falls through to the resolver/policy.
+//     Adding "+.ts.net" here would be wrong — it would FORCE fake-ip for the
+//     domain, the opposite of what we want.
+//     - rule: filter entries must be full rules with an action, otherwise
+//     parseFakeIPRules rejects the whole config.
+//
+// The policy entry is always written (overwriting any subscription value for
+// "+.ts.net"), because enabling tailscale means THIS node must own MagicDNS
+// resolution. The node name is the fixed tailscaleProxyName constant.
+func applyTailscaleDNS(dns *config.RawDNS) {
+	// (1) nameserver-policy → tailscale://<node>.
+	if dns.NameServerPolicy == nil {
+		dns.NameServerPolicy = orderedmap.New[string, any]()
+	}
+	dns.NameServerPolicy.Set(tsPolicyKey, "tailscale://"+tailscaleProxyName)
+
+	// (2) fake-ip-filter, mode-dependent.
+	switch dns.FakeIPFilterMode {
+	case C.FilterBlackList:
+		if !containsString(dns.FakeIPFilter, tsFilterEntry) {
+			dns.FakeIPFilter = append(dns.FakeIPFilter, tsFilterEntry)
+		}
+	case C.FilterWhiteList:
+		// Intentionally do nothing. In whitelist mode only listed domains use
+		// fake-ip; *.ts.net is not listed, so the skipper already routes it to
+		// real DNS where the policy above answers it. Adding "+.ts.net" here
+		// would invert the intent and force fake-ip for the domain.
+	case C.FilterRule:
+		if !containsString(dns.FakeIPFilter, tsFilterRule) {
+			dns.FakeIPFilter = append(dns.FakeIPFilter, tsFilterRule)
+		}
+	}
+}
+
+// containsString reports whether s is in list.
+func containsString(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func patchTun(cfg *config.RawConfig, _ string) error {

--- a/core/src/main/java/com/github/kr328/clash/core/model/ConfigurationOverride.kt
+++ b/core/src/main/java/com/github/kr328/clash/core/model/ConfigurationOverride.kt
@@ -56,6 +56,9 @@ data class ConfigurationOverride(
     @SerialName("hosts")
     var hosts: Map<String, String>? = null,
 
+    @SerialName("tailscale")
+    var tailscale: Tailscale = Tailscale(),
+
     @SerialName("unified-delay")
     var unifiedDelay: Boolean? = null,
 
@@ -247,6 +250,31 @@ data class ConfigurationOverride(
 
         @SerialName("override-destination")
         var overrideDestination: Boolean? = null,
+    )
+
+    /**
+     * UI-facing flat representation of the tailscale override (single node +
+     * routing). Serialized as a plain `tailscale` object in the override JSON;
+     * the kernel-side patchTailscale processor (see
+     * core/.../config/process.go) expands it into proxies / proxy-groups /
+     * rules. Kept as a plain @Serializable so it rides through the Android
+     * Parcel (IPC) path correctly.
+     *
+     * The proxy/group names are fixed constants on the kernel side
+     * ("Tailscale" / "Tailscale-Group"); there is no user-configurable name.
+     * A single `enabled` toggle controls creation — this lets the user keep a
+     * fully-default node (e.g. after clearing a one-time auth-key, or relying
+     * on tsnet interactive login with no options at all).
+     */
+    @Serializable
+    data class Tailscale(
+        var enabled: Boolean = false,
+        var hostname: String? = null,
+        var authKey: String? = null,
+        var controlUrl: String? = null,
+        var stateDir: String? = null,
+        var exitNode: String? = null,
+        var ipCidrs: List<String>? = null,
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {

--- a/design/src/main/java/com/github/kr328/clash/design/OverrideSettingsDesign.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/OverrideSettingsDesign.kt
@@ -225,6 +225,79 @@ class OverrideSettingsDesign(
                 placeholder = R.string.dont_modify,
             )
 
+            category(R.string.tailscale)
+
+            val tailscaleDeps: MutableList<Preference> = mutableListOf()
+
+            switch(
+                value = configuration.tailscale::enabled,
+                title = R.string.tailscale_enable,
+                summary = R.string.tailscale_enable_summary,
+            ) {
+                listener = OnChangedListener {
+                    tailscaleDeps.forEach {
+                        it.enabled = configuration.tailscale.enabled
+                    }
+                }
+            }
+
+            editableText(
+                value = configuration.tailscale::authKey,
+                adapter = NullableTextAdapter.String,
+                title = R.string.tailscale_field_auth_key,
+                placeholder = R.string.dont_modify,
+                empty = R.string.disabled,
+                configure = tailscaleDeps::add,
+            )
+
+            editableText(
+                value = configuration.tailscale::hostname,
+                adapter = NullableTextAdapter.String,
+                title = R.string.tailscale_field_hostname,
+                placeholder = R.string.dont_modify,
+                empty = R.string.disabled,
+                configure = tailscaleDeps::add,
+            )
+
+            editableText(
+                value = configuration.tailscale::controlUrl,
+                adapter = NullableTextAdapter.String,
+                title = R.string.tailscale_field_control_url,
+                placeholder = R.string.dont_modify,
+                empty = R.string.disabled,
+                configure = tailscaleDeps::add,
+            )
+
+            editableText(
+                value = configuration.tailscale::stateDir,
+                adapter = NullableTextAdapter.String,
+                title = R.string.tailscale_field_state_dir,
+                placeholder = R.string.dont_modify,
+                empty = R.string.disabled,
+                configure = tailscaleDeps::add,
+            )
+
+            editableText(
+                value = configuration.tailscale::exitNode,
+                adapter = NullableTextAdapter.String,
+                title = R.string.tailscale_field_exit_node,
+                placeholder = R.string.dont_modify,
+                empty = R.string.disabled,
+                configure = tailscaleDeps::add,
+            )
+
+            editableTextList(
+                value = configuration.tailscale::ipCidrs,
+                adapter = TextAdapter.String,
+                title = R.string.tailscale_ip_cidrs,
+                placeholder = R.string.tailscale_cidrs_hint,
+                configure = tailscaleDeps::add,
+            )
+
+            tailscaleDeps.forEach {
+                it.enabled = configuration.tailscale.enabled
+            }
+
             category(R.string.dns)
 
             val dnsDependencies: MutableList<Preference> = mutableListOf()

--- a/design/src/main/res/values-ja-rJP/strings.xml
+++ b/design/src/main/res/values-ja-rJP/strings.xml
@@ -264,4 +264,15 @@
     <string name="override_destination">Override Destination</string>
     <string name="import_from_qr_no_permission">カメラのアクセスが制限されています。設定から有効にしてください。</string>
     <string name="import_from_qr_exception">システムで予期しない例外が発生しました。</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">Enable Tailscale</string>
+t<string name="tailscale_enable_summary">Create a Tailscale proxy node and route tailnet traffic to it</string>
+    <string name="tailscale_field_hostname">Hostname</string>
+    <string name="tailscale_field_auth_key">Auth key</string>
+    <string name="tailscale_field_control_url">Control URL (optional, for headscale)</string>
+    <string name="tailscale_field_state_dir">State directory</string>
+    <string name="tailscale_field_exit_node">Exit node</string>
+    <string name="tailscale_ip_cidrs">Route IP CIDRs</string>
+    <string name="tailscale_cidrs_hint">empty = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-ko-rKR/strings.xml
+++ b/design/src/main/res/values-ko-rKR/strings.xml
@@ -264,4 +264,15 @@
     <string name="override_destination">Override Destination</string>
     <string name="import_from_qr_no_permission">카메라 접근이 제한되었습니다. 설정에서 허용해 주세요.</string>
     <string name="import_from_qr_exception">처리되지 않은 시스템 예외가 발생했습니다.</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">Enable Tailscale</string>
+t<string name="tailscale_enable_summary">Create a Tailscale proxy node and route tailnet traffic to it</string>
+    <string name="tailscale_field_hostname">Hostname</string>
+    <string name="tailscale_field_auth_key">Auth key</string>
+    <string name="tailscale_field_control_url">Control URL (optional, for headscale)</string>
+    <string name="tailscale_field_state_dir">State directory</string>
+    <string name="tailscale_field_exit_node">Exit node</string>
+    <string name="tailscale_ip_cidrs">Route IP CIDRs</string>
+    <string name="tailscale_cidrs_hint">empty = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-ru/strings.xml
+++ b/design/src/main/res/values-ru/strings.xml
@@ -328,4 +328,15 @@
     <string name="override_destination">Override Destination</string>
     <string name="import_from_qr_no_permission">Доступ к камере ограничен. Разрешите его в настройках.</string>
     <string name="import_from_qr_exception">Произошла не обрабатываемая системная ошибка.</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">Enable Tailscale</string>
+t<string name="tailscale_enable_summary">Create a Tailscale proxy node and route tailnet traffic to it</string>
+    <string name="tailscale_field_hostname">Hostname</string>
+    <string name="tailscale_field_auth_key">Auth key</string>
+    <string name="tailscale_field_control_url">Control URL (optional, for headscale)</string>
+    <string name="tailscale_field_state_dir">State directory</string>
+    <string name="tailscale_field_exit_node">Exit node</string>
+    <string name="tailscale_ip_cidrs">Route IP CIDRs</string>
+    <string name="tailscale_cidrs_hint">empty = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-vi/strings.xml
+++ b/design/src/main/res/values-vi/strings.xml
@@ -250,4 +250,15 @@
     <string name="import_from_qr">Nhập từ Mã QR</string>
     <string name="import_from_qr_no_permission">Quyền truy cập camera bị hạn chế. Vui lòng bật trong Cài đặt.</string>
     <string name="import_from_qr_exception">Đã xảy ra ngoại lệ hệ thống không xử lý được.</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">Enable Tailscale</string>
+t<string name="tailscale_enable_summary">Create a Tailscale proxy node and route tailnet traffic to it</string>
+    <string name="tailscale_field_hostname">Hostname</string>
+    <string name="tailscale_field_auth_key">Auth key</string>
+    <string name="tailscale_field_control_url">Control URL (optional, for headscale)</string>
+    <string name="tailscale_field_state_dir">State directory</string>
+    <string name="tailscale_field_exit_node">Exit node</string>
+    <string name="tailscale_ip_cidrs">Route IP CIDRs</string>
+    <string name="tailscale_cidrs_hint">empty = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-zh-rHK/strings.xml
+++ b/design/src/main/res/values-zh-rHK/strings.xml
@@ -261,4 +261,15 @@
     <string name="override_destination">Override Destination</string>
     <string name="import_from_qr_no_permission">相機權限受限，請前往設定開啟。</string>
     <string name="import_from_qr_exception">發生系統未知異常，操作失敗。</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">啟用 Tailscale</string>
+t<string name="tailscale_enable_summary">建立 Tailscale 代理節點並將尾網流量路由到它</string>
+    <string name="tailscale_field_hostname">主機名稱</string>
+    <string name="tailscale_field_auth_key">認證金鑰</string>
+    <string name="tailscale_field_control_url">控制伺服器位址（可選，用於自建 headscale）</string>
+    <string name="tailscale_field_state_dir">狀態目錄</string>
+    <string name="tailscale_field_exit_node">出口節點</string>
+    <string name="tailscale_ip_cidrs">路由 IP 段</string>
+    <string name="tailscale_cidrs_hint">留空 = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-zh-rTW/strings.xml
+++ b/design/src/main/res/values-zh-rTW/strings.xml
@@ -261,4 +261,15 @@
     <string name="override_destination">Override Destination</string>
     <string name="import_from_qr_no_permission">相機權限受限，請前往設定開啟。</string>
     <string name="import_from_qr_exception">發生系統未知異常，操作失敗。</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">啟用 Tailscale</string>
+t<string name="tailscale_enable_summary">建立 Tailscale 代理節點並將尾網流量路由到它</string>
+    <string name="tailscale_field_hostname">主機名稱</string>
+    <string name="tailscale_field_auth_key">認證金鑰</string>
+    <string name="tailscale_field_control_url">控制伺服器位址（可選，用於自建 headscale）</string>
+    <string name="tailscale_field_state_dir">狀態目錄</string>
+    <string name="tailscale_field_exit_node">出口節點</string>
+    <string name="tailscale_ip_cidrs">路由 IP 段</string>
+    <string name="tailscale_cidrs_hint">留空 = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -280,4 +280,15 @@
     <string name="shortcut_start_long">启动 Clash 服务</string>
     <string name="shortcut_stop_short">停止 Clash</string>
     <string name="shortcut_stop_long">停止 Clash 服务</string>
+
+    <string name="tailscale">Tailscale</string>
+t<string name="tailscale_enable">启用 Tailscale</string>
+t<string name="tailscale_enable_summary">创建 Tailscale 代理节点并将尾网流量路由到它</string>
+    <string name="tailscale_field_hostname">主机名</string>
+    <string name="tailscale_field_auth_key">认证密钥</string>
+    <string name="tailscale_field_control_url">控制服务器地址（可选，用于自建 headscale）</string>
+    <string name="tailscale_field_state_dir">状态目录</string>
+    <string name="tailscale_field_exit_node">出口节点</string>
+    <string name="tailscale_ip_cidrs">路由 IP 段</string>
+    <string name="tailscale_cidrs_hint">留空 = 100.64.0.0/10</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -370,4 +370,15 @@
     <string name="shortcut_start_long">Start Clash service</string>
     <string name="shortcut_stop_short">Stop Clash</string>
     <string name="shortcut_stop_long">Stop Clash service</string>
+
+    <string name="tailscale">Tailscale</string>
+    <string name="tailscale_enable">Enable Tailscale</string>
+    <string name="tailscale_enable_summary">Create a Tailscale proxy node and route tailnet traffic to it</string>
+    <string name="tailscale_field_hostname">Hostname</string>
+    <string name="tailscale_field_auth_key">Auth key</string>
+    <string name="tailscale_field_control_url">Control URL (optional, for headscale)</string>
+    <string name="tailscale_field_state_dir">State directory</string>
+    <string name="tailscale_field_exit_node">Exit node</string>
+    <string name="tailscale_ip_cidrs">Route IP CIDRs</string>
+    <string name="tailscale_cidrs_hint">empty = 100.64.0.0/10</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds a first-class **Tailscale** override to the override settings screen. Flipping the switch creates a Tailscale proxy node + a select group + routing rules + DNS wiring, so tailnet FQDNs (`*.ts.net`) and CGNAT IPs (`100.64.0.0/10`) reach the user's tailnet through MagicDNS without manual subscription editing.

## Why

CMFA already bundles the `tailscale` outbound type (mihomo's tsnet integration), but wiring it up today means hand-editing the subscription YAML — proxy node, proxy-group, rules, and critically the `nameserver-policy` that points `*.ts.net` at the `tailscale://` DNS transport. The latter is easy to miss: without it, MagicDNS FQDNs silently fall through to the system DNS and fail to resolve. This PR automates all of it from the UI.

## What it does

| Layer | Change |
|---|---|
| **Kotlin model** | New flat `ConfigurationOverride.Tailscale` — a single `enabled` toggle + optional fields (`authKey`, `hostname`, `controlUrl`, `stateDir`, `exitNode`, `ipCidrs`) |
| **Go (kernel)** | `patchTailscale` expands the override into a fixed-name proxy `Tailscale` + group `Tailscale-Group` + prepended rules; `patchDns` injects the `nameserver-policy` and fake-ip-filter entries |
| **UI / i18n** | New Tailscale category in override settings, with all fields gated on the `enabled` switch. 8 locales |

## Design choices (and the bugs they avoid)

- **Fixed node/group names (`Tailscale` / `Tailscale-Group`), not user-configurable.** A user-supplied name could collide with mihomo built-ins (`DIRECT`, `REJECT`, … → "duplicate name" load error) or embed `/` (which `url.Parse` splits into Host/Path, desyncing the DNS lookup key from the transport registration). Constants make both classes of bug structurally impossible.
- **`enabled` is a single boolean, not "any field non-empty".** Tailscale supports a fully-default node (interactive login, persistent state dir, auth-key cleared after first use). Inferring "enabled" from non-empty fields would drop the node exactly when the user wants to keep it running with defaults.
- **Both fixed names are cleared from both `cfg.Proxy` and `cfg.ProxyGroup` before append.** mihomo registers proxies and groups in one shared map, so a subscription-defined group named `Tailscale` would clash with our proxy even though we only append a group named `Tailscale-Group`. Clearing both names from both slices covers every cross-category collision.
- **`nameserver-policy` for `+.ts.net` is always overwritten.** If the subscription already has a `+.ts.net` policy pointing elsewhere, keeping it would silently leave MagicDNS broken — the opposite of what enabling the feature promises.
- **fake-ip-filter entry is shaped per `FakeIPFilterMode`**: `+.ts.net` for blacklist (default), nothing for whitelist (the policy short-circuits before fake-ip), and `DOMAIN-SUFFIX,ts.net,real-ip` for rule mode (a bare suffix fails `parseFakeIPRules`).
- **Short names (`nas`) are intentionally not supported.** tsnet's `QueryDNS` does not append the MagicDNS search suffix, so only full `*.ts.net` FQDNs (or IPs) resolve. This is documented in the code comments.

## Commits

1. `feat(core): add Tailscale override model` — Kotlin data class
2. `feat(core): inject Tailscale proxy, routing and DNS via override` — Go expansion + DNS wiring
3. `feat(design): add Tailscale override UI` — settings screen + strings

## Verification

- `gofmt` clean, `go build -tags "android cmfa"` + `go vet` pass
- Full `app:assembleAlphaRelease` succeeds (all 5 ABIs)
- Manually tested on device: enabling the switch with an auth-key creates the node, resolves `*.ts.net` via MagicDNS, and routes traffic to the Tailscale-Group

<img width="1220" height="2712" alt="Screenshot_2026-08-03-22-29-45-302_com github metacubex clash alpha" src="https://github.com/user-attachments/assets/6ccaa150-6ca7-4223-90b2-ec5f77457183" />

## Notes for reviewers

- The override is **single-instance** (one Tailscale node per profile). The model is a flat object, not a list.
- `routingEnabled` was intentionally folded into `enabled` after iteration — the two-stage toggle added complexity without enabling any real use case that a single switch doesn't cover.