### PR TITLE
Prevent invalid subscription responses from overwriting config.yaml

### DIFF
--- a/core/src/main/golang/native/config/fetch.go
+++ b/core/src/main/golang/native/config/fetch.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/metacubex/mihomo/adapter/provider"
 	clashHttp "github.com/metacubex/mihomo/component/http"
+	mihomoConfig "github.com/metacubex/mihomo/config"
 	RB "github.com/metacubex/mihomo/rules/bundle"
 )
 
@@ -44,6 +46,11 @@ func openUrl(ctx context.Context, url string) (io.ReadCloser, fetchHeader, error
 	if err != nil {
 		return nil, fetchHeader{}, err
 	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_ = response.Body.Close()
+
+		return nil, fetchHeader{}, fmt.Errorf("subscription request failed: %s", response.Status)
+	}
 
 	return response.Body, fetchHeader{
 		SubscriptionUserInfo:  response.Header.Get("subscription-userinfo"),
@@ -56,6 +63,20 @@ func openContent(url string) (io.ReadCloser, error) {
 }
 
 func fetch(url *U.URL, file string) (fetchHeader, error) {
+	return fetchWithValidator(url, file, nil)
+}
+
+func fetchConfiguration(url *U.URL, file string) (fetchHeader, error) {
+	return fetchWithValidator(url, file, func(data []byte) error {
+		if _, err := mihomoConfig.UnmarshalRawConfig(data); err != nil {
+			return fmt.Errorf("invalid configuration response: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func fetchWithValidator(url *U.URL, file string, validate func([]byte) error) (fetchHeader, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -77,6 +98,18 @@ func fetch(url *U.URL, file string) (fetchHeader, error) {
 	}
 
 	defer reader.Close()
+
+	if validate != nil {
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return fetchHeader{}, err
+		}
+		if err := validate(data); err != nil {
+			return fetchHeader{}, err
+		}
+
+		return header, writeFile(file, bytes.NewReader(data))
+	}
 
 	return header, writeFile(file, reader)
 }
@@ -171,7 +204,7 @@ func FetchAndValid(
 
 		reportStatus(string(bytes))
 
-		header, err := fetch(url, configPath)
+		header, err := fetchConfiguration(url, configPath)
 		if err != nil {
 			return err
 		}

--- a/core/src/main/golang/native/config/fetch_test.go
+++ b/core/src/main/golang/native/config/fetch_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	U "net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenURLRejectsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	body, _, err := openUrl(context.Background(), server.URL)
+	if body != nil {
+		_ = body.Close()
+		t.Fatal("expected no response body for an HTTP error")
+	}
+	if err == nil || !strings.Contains(err.Error(), "502 Bad Gateway") {
+		t.Fatalf("expected HTTP status error, got %v", err)
+	}
+}
+
+func TestFetchConfigurationRejectsInvalidResponseWithoutOverwriting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "检测到不受支持的客户端")
+	}))
+	t.Cleanup(server.Close)
+
+	profileDir := t.TempDir()
+	configPath := filepath.Join(profileDir, "config.yaml")
+	original := []byte("proxies: []\nrules: []\n")
+	if err := os.WriteFile(configPath, original, 0600); err != nil {
+		t.Fatalf("write existing configuration: %v", err)
+	}
+
+	url, err := U.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	if _, err := fetchConfiguration(url, configPath); err == nil || !strings.Contains(err.Error(), "invalid configuration response") {
+		t.Fatalf("expected invalid configuration error, got %v", err)
+	}
+
+	current, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read existing configuration: %v", err)
+	}
+	if string(current) != string(original) {
+		t.Fatal("invalid response overwrote the existing configuration")
+	}
+}
+
+func TestFetchConfigurationWritesValidResponse(t *testing.T) {
+	configuration := []byte("proxies: []\nrules: []\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(configuration)
+	}))
+	t.Cleanup(server.Close)
+
+	url, err := U.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if _, err := fetchConfiguration(url, configPath); err != nil {
+		t.Fatalf("fetch valid configuration: %v", err)
+	}
+
+	written, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read fetched configuration: %v", err)
+	}
+	if string(written) != string(configuration) {
+		t.Fatal("fetched configuration does not match the response")
+	}
+}


### PR DESCRIPTION
## Problem

When updating a profile, CMFA assumes that every response body is a valid Clash configuration.

If a subscription server returns an error page or informational text instead of YAML, CMFA currently:

1. accepts the response without checking its HTTP status;
2. truncates and overwrites the existing `config.yaml` with the response body;
3. only attempts to parse the file afterward.

This produces a misleading YAML error such as:

```text
cannot unmarshal !!str into config.RawConfig
```

More importantly, the previously valid configuration has already been replaced by the invalid response.

## Root cause

`openUrl` returned the response body regardless of the HTTP status, and the configuration download path passed that body directly to `writeFile`.

Configuration validation only happened later in `UnmarshalAndPatch`, after `config.yaml` had already been overwritten.

The original YAML involved in the reported case parses successfully with Mihomo. The parsing error was caused by a non-configuration response body from the subscription server, not by CRLF or flow-style YAML syntax.

## Reproduction

Use a subscription endpoint that returns either:

* HTTP 502 with an error page; or
* HTTP 200 with plain text such as `检测到不受支持的客户端`.

With an existing valid `config.yaml`, trigger a forced profile update.

Before this change, CMFA writes the response body to `config.yaml` and then reports a YAML unmarshalling error.

## Fix

* Reject non-2xx HTTP responses before reading them as subscription data.
* Parse downloaded profile content with `mihomo/config.UnmarshalRawConfig` before writing it.
* Preserve the existing `config.yaml` when the downloaded content is not a valid configuration.
* Keep generic provider downloads on the existing unvalidated fetch path to limit the behavior change to the main profile configuration.

## Tests

Added regression coverage for:

* rejecting an HTTP 502 response;
* rejecting an HTTP 200 plain-text response without overwriting the existing configuration;
* accepting and writing a valid Clash YAML response.

The tests were formatted and added to the affected Go package. Full local execution was blocked by unavailable cached build dependencies, so CI verification is still required.
