### PR TITLE
Enhance Android notifications with live updates and fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
 
     <!-- Workaround for Android 17+ cross profile loopback networking restrictions.
          This permission allows CMFA to connect to loopback addresses and ports bound

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,10 +56,10 @@ subprojects {
             }
 
             minSdk = 21
-            targetSdk = 35
+            targetSdk = 36
 
-            versionName = "2.11.33"
-            versionCode = 211033
+            versionName = "2.11.34"
+            versionCode = 211034
 
             resValue("string", "release_name", "v$versionName")
             resValue("integer", "release_code", "$versionCode")

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Gradle parallel build
-org.gradle.parallel=true
+org.gradle.parallel=trueorg.gradle.java.home=/opt/homebrew/Cellar/openjdk@21/21.0.12.1/libexec/openjdk.jdk/Contents/Home

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.8.0"
+agp = "8.9.1"
 kotlin = "2.1.0"
 ksp = "2.1.0-1.0.29"
 golang = "1.0.4"
 coroutine = "1.10.1"
-coreKtx = "1.8.0"
+coreKtx = "1.17.0"
 activity = "1.5.0"
 fragment = "1.5.0"
 appcompat = "1.4.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Tue Jan 14 14:06:42 CST 2025
+#Tue Sep 01 10:42:18 CST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/DynamicNotificationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/DynamicNotificationModule.kt
@@ -74,7 +74,7 @@ class DynamicNotificationModule(service: Service) : Module<Unit>(service) {
                     uploaded, downloaded
                 )
             ).setShortCriticalText(
-                "$downloaded ↓"
+                "$downloading ↓"
             ).build()
 
         notificationManager.notify(R.id.nf_clash_status, notification)

--- a/service/src/main/java/com/github/kr328/clash/service/clash/module/DynamicNotificationModule.kt
+++ b/service/src/main/java/com/github/kr328/clash/service/clash/module/DynamicNotificationModule.kt
@@ -1,12 +1,18 @@
 package com.github.kr328.clash.service.clash.module
 
+import android.Manifest
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.content.res.Resources
+import android.os.Build
 import android.os.PowerManager
+import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
+import androidx.core.content.pm.ShortcutInfoCompat
 import com.github.kr328.clash.common.compat.getColorCompat
 import com.github.kr328.clash.common.compat.pendingIntentFlags
 import com.github.kr328.clash.common.constants.Components
@@ -30,6 +36,8 @@ class DynamicNotificationModule(service: Service) : Module<Unit>(service) {
         .setOnlyAlertOnce(true)
         .setShowWhen(false)
         .setContentTitle("Not Selected")
+        .setRequestPromotedOngoing(true)
+        .setStyle(NotificationCompat.BigTextStyle())
         .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
         .setContentIntent(
             PendingIntent.getActivity(
@@ -43,6 +51,7 @@ class DynamicNotificationModule(service: Service) : Module<Unit>(service) {
 
     private val notificationManager = NotificationManagerCompat.from(service)
 
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
     private fun update() {
         val now = Clash.queryTrafficNow()
         val total = Clash.queryTrafficTotal()
@@ -64,8 +73,9 @@ class DynamicNotificationModule(service: Service) : Module<Unit>(service) {
                     R.string.clash_notification_content,
                     uploaded, downloaded
                 )
-            )
-            .build()
+            ).setShortCriticalText(
+                "$downloaded ↓"
+            ).build()
 
         notificationManager.notify(R.id.nf_clash_status, notification)
     }
@@ -95,10 +105,14 @@ class DynamicNotificationModule(service: Service) : Module<Unit>(service) {
                     }
                 }
                 profileLoaded.onReceive {
+                    builder.setContentTitle("Clash Meta")
+                    builder.setSmallIcon(R.drawable.ic_logo_service)
+                    builder.setOngoing(true)
+
                     builder.setContentTitle(StatusProvider.currentProfile ?: "Not selected")
                 }
                 if (shouldUpdate) {
-                    ticker.onReceive {
+                    ticker.onReceive @androidx.annotation.RequiresPermission(android.Manifest.permission.POST_NOTIFICATIONS) {
                         update()
                     }
                 }


### PR DESCRIPTION
This pull request introduces several updates to notification handling, dependency versions, and build configuration. The most significant changes are improvements to notification features, including support for promoted notifications and enhanced notification content, as well as updates to Gradle and Android dependencies for improved compatibility and performance.

**Notification enhancements:**
- Added the `POST_PROMOTED_NOTIFICATIONS` permission to `AndroidManifest.xml` to support promoted notifications.
- Updated `DynamicNotificationModule` to request promoted ongoing notifications, set a big text style, and use short critical text for improved notification appearance and behavior. [[1]](diffhunk://#diff-9f8229568829f2cba347a0dd6a9960d039dcb2de79afd68bd5acd56d8ee473f0R39-R40) [[2]](diffhunk://#diff-9f8229568829f2cba347a0dd6a9960d039dcb2de79afd68bd5acd56d8ee473f0L67-R78)
- Annotated notification update methods with `@RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)` to ensure correct permission usage. [[1]](diffhunk://#diff-9f8229568829f2cba347a0dd6a9960d039dcb2de79afd68bd5acd56d8ee473f0R54) [[2]](diffhunk://#diff-9f8229568829f2cba347a0dd6a9960d039dcb2de79afd68bd5acd56d8ee473f0R108-R115)

**Dependency and build configuration updates:**
- Upgraded Gradle to version 8.11.1 and updated the SHA256 checksum in `gradle-wrapper.properties`.
- Updated important Android and Kotlin library versions in `gradle/libs.versions.toml` (e.g., AGP to 8.9.1, coreKtx to 1.17.0).
- Modified `gradle.properties` to set the Java home for Gradle to OpenJDK 21.